### PR TITLE
BinSentry OTA for AWS Branch

### DIFF
--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -338,7 +338,7 @@ typedef struct OtaAppBuffer
 
 typedef struct OtaAgentContext
 {
-    OtaState_t state;                                      /*!< State of the OTA agent. */
+    volatile OtaState_t state;                             /*!< State of the OTA agent. */
     uint8_t pThingName[ otaconfigMAX_THINGNAME_LEN + 1U ]; /*!< Thing name + zero terminator. */
     OtaFileContext_t fileContext;                          /*!< Static array of OTA file structures. */
     uint32_t fileIndex;                                    /*!< Index of current file in the array. */

--- a/source/include/ota_os_interface.h
+++ b/source/include/ota_os_interface.h
@@ -257,6 +257,17 @@ typedef void * ( * OtaMalloc_t ) ( size_t size );
 typedef void ( * OtaFree_t ) ( void * ptr );
 
 /**
+ * @brief Delay task for specified milliseconds.
+ *
+ * This function sleeps the task for the specified milliseconds.
+ *
+ * @param[delay_ms]    Number of milliseconds to delay the task.
+ *
+ * @return             None.
+ */
+typedef void ( * OtaDelay_t ) ( uint32_t delay_ms );
+
+/**
  * @ingroup ota_struct_types
  * OTA Event Interface structure.
  */
@@ -302,6 +313,15 @@ typedef struct OtaMallocInterface
 
 /**
  * @ingroup ota_struct_types
+ * @brief OTA task delay interface.
+ */
+typedef struct OtaDelayInterface
+{
+    OtaDelay_t delay; /*!< @brief OTA task delay interface. */
+} OtaDelayInterface_t;
+
+/**
+ * @ingroup ota_struct_types
  * @brief  OTA OS Interface.
  */
 typedef struct OtaOSInterface
@@ -309,6 +329,7 @@ typedef struct OtaOSInterface
     OtaEventInterface_t event; /*!< @brief OTA Event interface. */
     OtaTimerInterface_t timer; /*!< @brief OTA Timer interface. */
     OtaMallocInterface_t mem;  /*!< @brief OTA memory interface. */
+    OtaDelayInterface_t delay; /*!< @brief OTA delay interface. */
 } OtaOSInterface_t;
 
 /* *INDENT-OFF* */

--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -422,6 +422,10 @@ typedef struct OtaEventData
     uint8_t data[ OTA_DATA_BLOCK_SIZE ]; /*!< Buffer for storing event information. */
     uint32_t dataLength;                 /*!< Total space required for the event. */
     bool bufferUsed;                     /*!< Flag set when buffer is used otherwise cleared. */
+#ifdef OTA_EVENT_BUFFER_DEBUG
+    OtaEvent_t event;
+    TickType_t creationTimestamp_ticks;
+#endif
 } OtaEventData_t;
 
 /**

--- a/source/ota.c
+++ b/source/ota.c
@@ -3454,12 +3454,15 @@ OtaState_t OTA_Shutdown( uint32_t ticksToWait,
                 /* NOTE: This technique is generally terrible because there is potential for time to slide [take longer
                  * to timeout than requested], much better to take a starting timestamp and look for elapse of
                  * ticksToWait while sleeping for a short interval in between checks */
+                ticks--;
                 /* NOTE: Added by BinSentry (Michael Vermeer), what an egregious error to not actually delay
                  * before decrementing tick count, this results in no timeout whatsoever which results
                  * in always returning immediately (guaranteed to not be shutdown if unsubscribeFlag is
                  * not 0) */
-                otaAgent.pOtaInterface->os.delay.delay(1);
-                ticks--;
+                if (otaAgent.pOtaInterface->os.delay.delay != NULL)
+                {
+                    otaAgent.pOtaInterface->os.delay.delay(1);
+                }
             }
         }
     }

--- a/source/ota.c
+++ b/source/ota.c
@@ -3454,10 +3454,11 @@ OtaState_t OTA_Shutdown( uint32_t ticksToWait,
                 // NOTE: This technique is generally terrible because there is potential for time to slide [take longer
                 // to timeout than requested], much better to take a starting timestamp and look for elapse of
                 // ticksToWait while sleeping for a short interval in between checks
-                vTaskDelay(1);  // Added by BinSentry (Michael Vermeer), what an egregious error to not actually delay
-                                // before decrementing tick count, this results in no timeout whatsoever which results
-                                // in always returning immediately (guaranteed to not be shutdown if unsubscribeFlag is
-                                // not 0)
+                // NOTE: Added by BinSentry (Michael Vermeer), what an egregious error to not actually delay
+                // before decrementing tick count, this results in no timeout whatsoever which results
+                // in always returning immediately (guaranteed to not be shutdown if unsubscribeFlag is
+                // not 0)
+                otaAgent.pOtaInterface->os.delay.delay(1);
                 ticks--;
             }
         }

--- a/source/ota.c
+++ b/source/ota.c
@@ -3451,6 +3451,13 @@ OtaState_t OTA_Shutdown( uint32_t ticksToWait,
              */
             while( ( ticks > 0U ) && ( otaAgent.state != OtaAgentStateStopped ) ) /* LCOV_EXCL_BR_LINE */
             {
+                // NOTE: This technique is generally terrible because there is potential for time to slide [take longer
+                // to timeout than requested], much better to take a starting timestamp and look for elapse of
+                // ticksToWait while sleeping for a short interval in between checks
+                vTaskDelay(1);  // Added by BinSentry (Michael Vermeer), what an egregious error to not actually delay
+                                // before decrementing tick count, this results in no timeout whatsoever which results
+                                // in always returning immediately (guaranteed to not be shutdown if unsubscribeFlag is
+                                // not 0)
                 ticks--;
             }
         }

--- a/source/ota.c
+++ b/source/ota.c
@@ -3451,13 +3451,13 @@ OtaState_t OTA_Shutdown( uint32_t ticksToWait,
              */
             while( ( ticks > 0U ) && ( otaAgent.state != OtaAgentStateStopped ) ) /* LCOV_EXCL_BR_LINE */
             {
-                // NOTE: This technique is generally terrible because there is potential for time to slide [take longer
-                // to timeout than requested], much better to take a starting timestamp and look for elapse of
-                // ticksToWait while sleeping for a short interval in between checks
-                // NOTE: Added by BinSentry (Michael Vermeer), what an egregious error to not actually delay
-                // before decrementing tick count, this results in no timeout whatsoever which results
-                // in always returning immediately (guaranteed to not be shutdown if unsubscribeFlag is
-                // not 0)
+                /* NOTE: This technique is generally terrible because there is potential for time to slide [take longer
+                 * to timeout than requested], much better to take a starting timestamp and look for elapse of
+                 * ticksToWait while sleeping for a short interval in between checks */
+                /* NOTE: Added by BinSentry (Michael Vermeer), what an egregious error to not actually delay
+                 * before decrementing tick count, this results in no timeout whatsoever which results
+                 * in always returning immediately (guaranteed to not be shutdown if unsubscribeFlag is
+                 * not 0) */
                 otaAgent.pOtaInterface->os.delay.delay(1);
                 ticks--;
             }

--- a/source/portable/os/ota_os_freertos.c
+++ b/source/portable/os/ota_os_freertos.c
@@ -32,6 +32,7 @@
 #include "FreeRTOS.h"
 #include "timers.h"
 #include "queue.h"
+#include "task.h"
 
 /* OTA OS POSIX Interface Includes.*/
 #include "ota_os_freertos.h"
@@ -357,4 +358,9 @@ void * Malloc_FreeRTOS( size_t size )
 void Free_FreeRTOS( void * ptr )
 {
     vPortFree( ptr );
+}
+
+void Delay_FreeRTOS( uint32_t delay_ms )
+{
+    vTaskDelay( pdMS_TO_TICKS( delay_ms ) );
 }

--- a/source/portable/os/ota_os_freertos.h
+++ b/source/portable/os/ota_os_freertos.h
@@ -165,4 +165,16 @@ void * Malloc_FreeRTOS( size_t size );
 
 void Free_FreeRTOS( void * ptr );
 
+/**
+ * @brief Delay task.
+ *
+ * This function delays the task by the specified milliseconds.
+ *
+ * @param[delay_ms]    Number of milliseconds to delay.
+ *
+ * @return             None.
+ */
+
+void Delay_FreeRTOS( uint32_t delay_ms );
+
 #endif /* ifndef _OTA_OS_FREERTOS_H_ */


### PR DESCRIPTION
- Fixed OTA_Shutdown() which doesn't properly handle timeout
- Added #ifdef to allow tracking of OtaEventData_t buffers to determine event they hold and how long the buffer has been in use
- Added new os.delay.delay() interface in order to support fixing OTA_Shutdown()